### PR TITLE
Remove facebook login method's initialization

### DIFF
--- a/social/facebook/src/main/kotlin/com/livetyping/facebook/FacebookInitializer.kt
+++ b/social/facebook/src/main/kotlin/com/livetyping/facebook/FacebookInitializer.kt
@@ -1,14 +1,13 @@
 package com.livetyping.facebook
 
 import android.app.Application
-import com.facebook.appevents.AppEventsLogger
 import com.livetyping.logincore.SocialInitializer
 
 
 class FacebookInitializer : SocialInitializer {
 
     override fun init(app: Application) {
-        AppEventsLogger.activateApp(app)
+        // pass
     }
 
 }


### PR DESCRIPTION
Remove facebook login method's initialization

Reason: The initialization methods are now called internally by the sdk itself on app's start